### PR TITLE
Fix core-pipeline Helm charts for dev and prod deployments

### DIFF
--- a/charts/core-pipeline/values-dev.yaml
+++ b/charts/core-pipeline/values-dev.yaml
@@ -37,6 +37,28 @@ autoscaling:
 env:
   NODE_ENV: development
   LOG_LEVEL: debug
+  LOG_PRETTY: "true"
+  PORT: "3000"
+  METRICS_ENABLED: "true"
+  METRICS_PREFIX: core_pipeline
+  TRACING_ENABLED: "true"
+  OTEL_SERVICE_NAME: core-pipeline-dev
+  OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo.monitoring:4318
+  SERVICE_VERSION: "1.0.0"
+  # Kafka - Dev environment
+  KAFKA_BROKERS: kafka.kafka.svc.cluster.local:9092
+  KAFKA_BROKER: kafka.kafka.svc.cluster.local:9092
+  KAFKA_CLIENT_ID: core-pipeline-dev
+  KAFKA_GROUP_ID: core-pipeline-dev-group
+  KAFKA_CONSUMER_GROUP: core-pipeline-dev-group
+  # PostgreSQL - Dev environment
+  POSTGRES_HOST: postgresql.database.svc.cluster.local
+  POSTGRES_PORT: "5432"
+  POSTGRES_DB: core_pipeline_dev
+  POSTGRES_USER: core_user
+  # Redis - Dev environment
+  REDIS_HOST: redis-master.redis.svc.cluster.local
+  REDIS_PORT: "6379"
   
 persistence:
   enabled: false
@@ -46,3 +68,7 @@ networkPolicy:
 
 serviceMonitor:
   enabled: false
+
+secrets:
+  POSTGRES_PASSWORD: core_password_dev
+  REDIS_PASSWORD: ""

--- a/charts/core-pipeline/values-prod.yaml
+++ b/charts/core-pipeline/values-prod.yaml
@@ -41,7 +41,29 @@ autoscaling:
 
 env:
   NODE_ENV: production
-  LOG_LEVEL: warn
+  LOG_LEVEL: info
+  LOG_PRETTY: "false"
+  PORT: "3000"
+  METRICS_ENABLED: "true"
+  METRICS_PREFIX: core_pipeline
+  TRACING_ENABLED: "true"
+  OTEL_SERVICE_NAME: core-pipeline-prod
+  OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo.monitoring:4318
+  SERVICE_VERSION: "1.0.0"
+  # Kafka - Production environment
+  KAFKA_BROKERS: kafka.kafka.svc.cluster.local:9092
+  KAFKA_BROKER: kafka.kafka.svc.cluster.local:9092
+  KAFKA_CLIENT_ID: core-pipeline-prod
+  KAFKA_GROUP_ID: core-pipeline-prod-group
+  KAFKA_CONSUMER_GROUP: core-pipeline-prod-group
+  # PostgreSQL - Production environment
+  POSTGRES_HOST: postgresql.database.svc.cluster.local
+  POSTGRES_PORT: "5432"
+  POSTGRES_DB: core_pipeline
+  POSTGRES_USER: core_user
+  # Redis - Production environment  
+  REDIS_HOST: redis-master.redis.svc.cluster.local
+  REDIS_PORT: "6379"
 
 persistence:
   enabled: true
@@ -79,3 +101,7 @@ serviceMonitor:
 podDisruptionBudget:
   enabled: true
   minAvailable: 2
+
+secrets:
+  POSTGRES_PASSWORD: core_password_prod
+  REDIS_PASSWORD: ""

--- a/charts/core-pipeline/values.yaml
+++ b/charts/core-pipeline/values.yaml
@@ -68,7 +68,8 @@ autoscaling:
   targetMemoryUtilizationPercentage: 80
 
 livenessProbe:
-  tcpSocket:
+  httpGet:
+    path: /health
     port: http
   initialDelaySeconds: 30
   periodSeconds: 10
@@ -76,7 +77,8 @@ livenessProbe:
   failureThreshold: 3
 
 readinessProbe:
-  tcpSocket:
+  httpGet:
+    path: /health
     port: http
   initialDelaySeconds: 10
   periodSeconds: 5
@@ -84,7 +86,8 @@ readinessProbe:
   failureThreshold: 3
 
 startupProbe:
-  tcpSocket:
+  httpGet:
+    path: /health
     port: http
   initialDelaySeconds: 0
   periodSeconds: 10
@@ -100,29 +103,34 @@ env:
   NODE_ENV: production
   PORT: "3000"
   LOG_LEVEL: info
+  LOG_PRETTY: "false"
   API_PREFIX: ""
   SWAGGER_ENABLED: "true"
   SWAGGER_PATH: "swagger"
   METRICS_ENABLED: "true"
+  METRICS_PREFIX: core_pipeline
   TRACING_ENABLED: "true"
   OTEL_SERVICE_NAME: core-pipeline
   OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo.monitoring:4318
+  SERVICE_VERSION: "1.0.0"
   # Kafka
   KAFKA_BROKERS: kafka.kafka.svc.cluster.local:9092
+  KAFKA_BROKER: kafka.kafka.svc.cluster.local:9092
   KAFKA_CLIENT_ID: core-pipeline
   KAFKA_GROUP_ID: core-pipeline-group
+  KAFKA_CONSUMER_GROUP: core-pipeline-group
   # PostgreSQL
   POSTGRES_HOST: postgresql.database.svc.cluster.local
   POSTGRES_PORT: "5432"
   POSTGRES_DB: core_pipeline
+  POSTGRES_USER: core_user
   # Redis
   REDIS_HOST: redis-master.redis.svc.cluster.local
   REDIS_PORT: "6379"
 
 secrets:
-  POSTGRES_USER: core_user
   POSTGRES_PASSWORD: core_password
-  REDIS_PASSWORD: redis_password
+  REDIS_PASSWORD: ""
 
 configMap:
   enabled: true

--- a/dev-core-pipeline.yaml
+++ b/dev-core-pipeline.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: 'git@github.com:uz0/core-pipeline.git'
+    repoURL: 'https://github.com/uz0/core-charts.git'
     targetRevision: main
     path: charts/core-pipeline
     helm:

--- a/prod-core-pipeline.yaml
+++ b/prod-core-pipeline.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: 'git@github.com:uz0/core-pipeline.git'
+    repoURL: 'https://github.com/uz0/core-charts.git'
     targetRevision: main
     path: charts/core-pipeline
     helm:


### PR DESCRIPTION
## Summary
- Fixed ArgoCD application configurations to use correct repository URLs
- Added all required environment variables for core-pipeline service
- Updated health check probes to use HTTP endpoints

## Changes Made

### ArgoCD Applications
- Changed repository URL from `git@github.com:uz0/core-pipeline.git` to `https://github.com/uz0/core-charts.git` for both dev and prod

### Environment Variables
Added missing required variables based on .env.example:
- `LOG_PRETTY` - Log formatting configuration  
- `METRICS_PREFIX` - Metrics naming prefix
- `SERVICE_VERSION` - Application version for tracing
- `KAFKA_BROKER` - Single broker endpoint (required by app)
- `KAFKA_CONSUMER_GROUP` - Kafka consumer group configuration
- `POSTGRES_USER` - Moved from secrets to env vars

### Health Checks
- Changed from TCP socket checks to HTTP GET requests on `/health` endpoint
- This provides better application health monitoring

### Environment-specific Configuration
- Dev: Using `core_pipeline_dev` database and `-dev` suffixed Kafka client IDs
- Prod: Using `core_pipeline` database and `-prod` suffixed Kafka client IDs

## Test Plan
- [ ] Deploy to dev environment and verify all pods start successfully
- [ ] Check that all environment variables are properly injected
- [ ] Verify health checks are working (pods become ready)
- [ ] Test Kafka connectivity
- [ ] Test PostgreSQL connectivity  
- [ ] Test Redis connectivity
- [ ] Deploy to production after dev validation